### PR TITLE
Add labels and fix links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,38 +6,43 @@ about: Create a report to help us improve
 
 _When issuing a bug report please include as many of the below details as possible. If you find a Closed issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one._
 
-**Describe the bug**
+### Describe the bug
 
 A clear and concise description of what the bug is.
 
 **To Reproduce**
+
 Steps to reproduce the behaviour:
 1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+2. Click on '...'
+3. Scroll down to '...'
 4. See error
 
 **Reproduces how often:**
 
 What percentage of the time does it reproduce, if you know?
 
-
 **Expected behaviour**
+
 A clear and concise description of what you expected to happen.
 
 **Screenshots**
+
 If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
+
  - OS: [e.g. iOS]
  - Browser [e.g. chrome, safari]
  - Version [e.g. 22]
 
 **Smartphone (please complete the following information):**
+
  - Device: [e.g. iPhone6]
  - OS: [e.g. iOS8.1]
  - Browser [e.g. stock browser, safari]
  - Version [e.g. 22]
 
 **Additional context**
+
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,28 +4,32 @@ about: Suggest an idea for this project
 
 ---
 
+### Describe the feature
+
+A clear and concise description of what the feature is.
+
 **Is your feature request related to a problem? Please describe.**
+
 - A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 - If applicable describe the current behaviour and explain which behaviour you expected to see instead.
 
 **Describe the solution you'd like and why**
+
 - A short but clear and concise description of what you want to happen. 
 - Why would this change be beneficial and for who?
 
-**Breakdown of proposed feature*
-Step-by-step breakdown of the proposed feature with examples 
-
-- 
--
-
 **Prerequisites** 
+
 Is there anything required that might block the progress of this feature
 
 **Examples of similar work**
+
 If applicable, give examples where you have seen this feature before.
 
 **Describe alternatives you've considered**
+
 A clear and concise description of any alternative solutions or features you've considered.
 
 **Additional context**
+
 Add any other context or screenshots about the feature request here.

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -24,23 +24,25 @@ This document outlines the different ways you can contribute to the UNiDAYS repo
   * [Git Commit Messages](#git-commit-messages)
   * [JavaScript Style Guide](#javascript-style-guide)
   * [CSS Style Guide](#css-style-guide)
+  * [DotNet XUnit Testing Styleguide](#dotnet-xunit-testing-styleguide)
+  * [Documentation Styleguide](#documentation-styleguide)
 
 ## How Can I Contribute?
 
-### Reporting Bugs :bug:
+### Reporting Bugs
 
-When issuing a bug report please include as many of details on [the bug report template](bug_report.md) as possible. If you find a Closed issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one. Please label the any bug report issues with `bug`.
+When issuing a bug report please include as many of details on [the bug report template](./ISSUE_TEMPLATE/bug_report.md) as possible. If you find a Closed issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one. Please label the any bug report issues with `bug`.
 
-### Suggesting Enhancements 🔎
+### Suggesting Enhancements
 
 Enhancements may include completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion and find related suggestions.
 
-First of all please do a search on the issues already present to see if it's an enhancement that hasn't previously been suggested. If it has, maybe join the discussion on the pre-existing issue. This is to help reduce duplication of issues. If it hasn't been raised previously, please include as many details as you can using [the feature request template](feature_request.md). Label the raised feature request as `enhancement`
+First of all please do a search on the issues already present to see if it's an enhancement that hasn't previously been suggested. If it has, maybe join the discussion on the pre-existing issue. This is to help reduce duplication of issues. If it hasn't been raised previously, please include as many details as you can using [the feature request template](./ISSUE_TEMPLATE/feature_request.md). Label the raised feature request as `enhancement`
 
 ### Labels For Issues
 
 | Label       | Purpose             |
-| ------------- |:----------------:| -----:|
+| ------------- |:----------------:|
 | up-for-grabs     | An issue that is ready and has enough information to be picked up  |
 | docs     | An issue that only relates to writing docs |
 | easy     | Difficulty level: any level of experience can pick this issue up |
@@ -51,7 +53,7 @@ First of all please do a search on the issues already present to see if it's an 
 | fix  | Fixing a pre-existing problem with the code      |
 
 
-### Pull Requests :thought_balloon:
+### Pull Requests
 
 - Create branch. If there is an issue, have the branch name related to the linked issue, otherwise give it a descriptive name relating to what the work covers. See some examples below.
 
@@ -61,7 +63,7 @@ First of all please do a search on the issues already present to see if it's an 
 | enhancement      | Making things _better_ but without fixing an issue     |   enhancement_improveperformanceofquery |
 | fix  | Fixing a pre-existing problem with the code that isn't an issue      | fix_acceptnullsforinput |
 
-- Open a Pull Request with the details listed in the [pull request template](pull_request_template.md). The sections of this template should show in the body of any new pull request automatically. 
+- Open a Pull Request with the details listed in the [pull request template](../pull_request_template.md). The sections of this template should show in the body of any new pull request automatically. 
 
 - Please ensure that any changes you make comply with our [style guides](#style-guides).
 
@@ -69,7 +71,7 @@ First of all please do a search on the issues already present to see if it's an 
 
 - Make a comment with the pull request in any issues it relates to.
 
-### Your First Code Contribution? :computer:
+### Your First Code Contribution?
 
 We will make efforts to label issues with `beginner` if we think they should only require a few lines of code, and a test or two. This is in order to help those who want to contribute but don't necessarily have much experience in doing so.
 
@@ -93,6 +95,14 @@ A full and up to date JavaScript style guide with examples can be accessed [here
 ### CSS Style Guide
 
 A full and up to date css style guide with examples can be accessed [here](https://github.com/johnnolan/StyleGuide/tree/master/CSS).
+
+## DotNet XUnit Testing Styleguide
+
+In this project our tests are written using [xUnit](https://xunit.github.io/docs/getting-started-dotnet-core) and [Fluent Assertions](https://fluentassertions.com/). We would appreciate if you test cover your code using the same tooling and try to keep to a similar style that's in the project. This is to help it remain consistent and easier to maintain.
+
+## Documentation Styleguide
+
+For anything changing the user experience or externally visible implementation, please update the README.md as part of your pull request.
 
 ## Licencing
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -88,7 +88,7 @@ We request that, where possible, you stick to the following format for your comm
 
 For reference, [this blog](https://chris.beams.io/posts/git-commit/) encourages a similar style.
 
-### JavaScript Styleguide
+### JavaScript Style Guide
 
 A full and up to date JavaScript style guide with examples can be accessed [here](https://github.com/MyUNiDAYS/StyleGuide/tree/master/Javascript).
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -20,10 +20,10 @@ This document outlines the different ways you can contribute to the UNiDAYS repo
   * [Pull Requests](#pull-requests)
   * [Your First Code Contribution](#your-first-code-contribution)
 
-[Styleguides](#styleguides)
+[Style Guides](#style-guides)
   * [Git Commit Messages](#git-commit-messages)
-  * [JavaScript Styleguide](#javascript-styleguide)
-  * [CSS Styleguide](#css-styleguide)
+  * [JavaScript Style Guide](#javascript-style-guide)
+  * [CSS Style Guide](#css-style-guide)
 
 ## How Can I Contribute?
 
@@ -63,7 +63,7 @@ First of all please do a search on the issues already present to see if it's an 
 
 - Open a Pull Request with the details listed in the [pull request template](pull_request_template.md). The sections of this template should show in the body of any new pull request automatically. 
 
-- Please ensure that any changes you make comply with our [styleguides](#styleguides).
+- Please ensure that any changes you make comply with our [style guides](#style-guides).
 
 -	Include screenshots and animated GIFs in your pull request whenever possible.
 
@@ -73,7 +73,7 @@ First of all please do a search on the issues already present to see if it's an 
 
 We will make efforts to label issues with `beginner` if we think they should only require a few lines of code, and a test or two. This is in order to help those who want to contribute but don't necessarily have much experience in doing so.
 
-## Styleguides
+## Style Guides
 
 ### Git Commit Messages
 
@@ -90,7 +90,7 @@ For reference, [this blog](https://chris.beams.io/posts/git-commit/) encourages 
 
 A full and up to date JavaScript style guide with examples can be accessed [here](https://github.com/MyUNiDAYS/StyleGuide/tree/master/Javascript).
 
-### CSS Styleguide
+### CSS Style Guide
 
 A full and up to date css style guide with examples can be accessed [here](https://github.com/johnnolan/StyleGuide/tree/master/CSS).
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -16,6 +16,7 @@ This document outlines the different ways you can contribute to the UNiDAYS repo
 [How Can I Contribute?](#how-can-i-contribute)
   * [Reporting Bugs](#reporting-bugs)
   * [Suggesting Enhancements](#suggesting-enhancements)
+  * [Labels For Issues](#labels-for-issues)
   * [Pull Requests](#pull-requests)
   * [Your First Code Contribution](#your-first-code-contribution)
 
@@ -35,6 +36,20 @@ When issuing a bug report please include as many of details on [the bug report t
 Enhancements may include completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion and find related suggestions.
 
 First of all please do a search on the issues already present to see if it's an enhancement that hasn't previously been suggested. If it has, maybe join the discussion on the pre-existing issue. This is to help reduce duplication of issues. If it hasn't been raised previously, please include as many details as you can using [the feature request template](feature_request.md). Label the raised feature request as `enhancement`
+
+### Labels For Issues
+
+| Label       | Purpose             |
+| ------------- |:----------------:| -----:|
+| up-for-grabs     | An issue that is ready and has enough information to be picked up  |
+| docs     | An issue that only relates to writing docs |
+| easy     | Difficulty level: any level of experience can pick this issue up |
+| medium     | Difficulty level: some experience of the domain or language will be needed to pick this issue up  |
+| hard     |Difficulty level: a lot of experience of the domain or language will be needed to pick this issue up |
+| insane     | Difficulty level: you need to be a total wizard to figure this out |
+| enhancement      | Making things better but without fixing an issue     |   
+| fix  | Fixing a pre-existing problem with the code      |
+
 
 ### Pull Requests :thought_balloon:
 
@@ -73,7 +88,7 @@ For reference, [this blog](https://chris.beams.io/posts/git-commit/) encourages 
 
 ### JavaScript Styleguide
 
-A full and up to date JavaScript style guide with examples can be accessed [here](https://github.com/johnnolan/StyleGuide/tree/master/Javascript).
+A full and up to date JavaScript style guide with examples can be accessed [here](https://github.com/MyUNiDAYS/StyleGuide/tree/master/Javascript).
 
 ### CSS Styleguide
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -45,7 +45,7 @@ Project maintainers who do not follow or enforce the Code of Conduct in good fai
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], [version 1.4][version]
 
 [homepage]: http://contributor-covenant.org
 [version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If there is anything you think should be changed or altered, feel free to open a
 	Outlines the behaviours we do and do not tolerate, our responsibilities as maintainers and contributors, and how to action when you think the code of conduct has been broken.
 
 - [Contributing document](.github/contributing.md)
-	Guidelines on how to contribute including raising bugs or feature requests, opening pull requests and our styleguides.
+	Guidelines on how to contribute including raising bugs or feature requests, opening pull requests and our style guides.
 
 - Templates
 	For [bug reports](.github/ISSUE_TEMPLATE/bug_report.md), [feature requests](.github/ISSUE_TEMPLATE/feature_request.md) and [pull requests](./pull_request_template.md).

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,7 +7,7 @@
 
 <!--
 
-We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.
 
 -->
 
@@ -24,11 +24,6 @@ We must be able to understand the design of your change from this description. I
 <!--
 
 What process did you follow to verify that your change has the desired effects?
-
-- How did you verify that all new functionality works as expected?
-- How did you verify that all changed functionality works as expected?
-- How did you verify that the change has not introduced any regressions?
-
 Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.
 
 -->


### PR DESCRIPTION
### Requirements

Link to the JS UNiDAYS style guide

### Description of the Change

- Add section on which labels to add to issues
- Fix link to JavaScript Style Guide
- Change spelling from Styleguide too Style Guide

### Benefits

Removes one of the places we are linking to an employees personal style guide

### Possible Drawbacks

N/A

### Verification Process

N/A

### Applicable Issues

N/A